### PR TITLE
WS-24: fixed the sightings endpoint

### DIFF
--- a/backend/Controllers/SightingController.cs
+++ b/backend/Controllers/SightingController.cs
@@ -6,6 +6,8 @@ using WhaleSpotting.Models.Response;
 
 namespace WhaleSpotting.Controllers
 {
+    [ApiController]
+    [Route("/sightings")]
     public class SightingController : ControllerBase
     {
         private readonly ISightingService _sightingService;


### PR DESCRIPTION
We have just fixed the small bug - Missing an URL in Sighting Controller file.