### PR TITLE
WS-00: Fix sighting form

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,14 +18,14 @@ const Routes: React.FunctionComponent = () => {
       <Route exact path="/sightings">
         <Sightings />
       </Route>
+      <Route exact path="/sightings/create">
+        <CreateSightingPage />
+      </Route>
       <Route exact path="/sightings/:id">
         <SightingPage />
       </Route>
       <Route exact path="/admin/login">
         <LoginPage />
-      </Route>
-      <Route exact path="/sightings/create">
-        <CreateSightingPage />
       </Route>
     </Switch>
   );


### PR DESCRIPTION
The sighting form routing meant that the route "/sightings/create" was
actually directing to the sighting page, attempting to retrieve the
sighting with id "create" (which obviously doesn't exist). This commit
fixes that by moving the "/sightings/create" route before the ":id" one.